### PR TITLE
chore: enable rule "useHookAtTopLevel"

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,9 @@
         "noExcessiveCognitiveComplexity": "warn",
         "useSimplifiedLogicExpression": "off"
       },
+      "correctness": {
+        "useHookAtTopLevel": "error"
+      },
       "performance": {
         "noBarrelFile": "off",
         "noReExportAll": "off"


### PR DESCRIPTION
oven-webappでreact hooks をトップレベル以外で使用してもlintエラーになっていないようでした
see [usePublicEventByUserStatus](https://github.com/jubilee-works/oven-webapp/blob/192fe026707ce94875ad6bc767e0fdc1747afae0/frontend/src/components/containers/hooks/publicCalendars/usePublicEventByUserStatus.ts#L10-L19)

```ts
export const usePublicEventByUserStatus = ({
  aliasCode,
  publicEventId,
}: Options) => {
  const { isManager } = useAuthenticatedManager({ aliasCode });

  return isManager
    ? useGetManagedPublicEvent({ aliasCode, publicEventId })
    : useGetPublicEvent({ aliasCode, publicEventId });
};
```

biomeのrecommendedの設定に `useExhaustiveDependencies` は含まれているのに対し `useHookAtTopLevel` が含まれていないのが原因のようです
see https://biomejs.dev/linter/rules/
(☑がついてるやつがrecommendedのもの)
![image](https://github.com/user-attachments/assets/296cade0-b6c1-4d25-b30e-414d6a469b1e)

React以外のプロジェクトでこのエラーを検知してしまう煩わしさより、Reactプロジェクトで検知漏れが起きるリスクの方が大きそうなのでこちらで対応しました！
何か追加してない理由があれば教えてください 🙇 