### PR TITLE
feat: add useConsistentObjectDefinition rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -85,7 +85,7 @@
         "noSkippedTests": "warn"
       },
       "nursery": {
-        "noNestedComponentDefinitions": "off"
+        "useConsistentObjectDefinition": "error"
       }
     }
   },


### PR DESCRIPTION
## 概要
biome.jsonのnursery設定に`useConsistentObjectDefinition`ルールを追加しました。

## 変更内容
- nurseryルールセクションに`useConsistentObjectDefinition: "error"`を追加
- 既存の`noNestedComponentDefinitions`ルールを置き換え

## 目的
このルールは、オブジェクト定義の一貫性を保つためのものです。オブジェクトの定義方法を統一することで、コードの可読性と保守性を向上させます。

## 参考
- [Biome ルールドキュメント](https://next.biomejs.dev/linter/rules/use-consistent-object-definition/)

## 影響範囲
- 設定ファイルの構文は有効
- オブジェクト定義の一貫性チェックが有効化されます