### PR TITLE
💚 Fix bump version script

### DIFF
--- a/.github/workflows/version-sync-push.yml
+++ b/.github/workflows/version-sync-push.yml
@@ -31,15 +31,17 @@ jobs:
             exit 1
           fi
           echo NEXT_VERSION=$(echo $NEXT_VERSION) >> $GITHUB_ENV
-      - name: Prepare to use formatter
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
         if: env.CURRENT_VERSION != env.NEXT_VERSION
-        uses: oven-sh/setup-bun@v2
-
+        with:
+          deno-version-file: .tool-versions
+          cache: true
       - name: Sync version
         if: env.CURRENT_VERSION != env.NEXT_VERSION
         run: |
           echo $(jq ".version=\"${{ env.NEXT_VERSION }}\"" deno.json) > deno.json
-          bunx @biomejs/biome format --write deno.json
+          deno fmt deno.json
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add deno.json


### PR DESCRIPTION
This pull request updates the version synchronization workflow to use Deno for formatting instead of Bun/Biome. The main change is switching the setup and formatting steps to use Deno, ensuring consistency with the project's toolchain.

**Workflow tooling update:**

* Replaced Bun/Biome setup with Deno by adding the `denoland/setup-deno@v2` action, using the `.tool-versions` file for version management and enabling caching.
* Changed the formatting command for `deno.json` from `bunx @biomejs/biome format` to `deno fmt`, aligning formatting with Deno's native tooling.