### PR TITLE
chore: extend renovate config with org supply-chain preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "github>jubilee-works/timetree-github-actions:renovate-supply-chain"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
### 概要

renovate.json の extends に `github>jubilee-works/timetree-github-actions:renovate-supply-chain` を追加しました。

これは [renovate-supply-chain.json](https://github.com/jubilee-works/timetree-github-actions/blob/main/renovate-supply-chain.json) が全 datasource 7日 cooldown + GitHub Actions digest 固定を提供するプリセットで、org共通のプリセットに一本化することで各リポジトリごとの設定の重複・ばらつきをなくす目的です。

### 使用した生成AI
- [x] Claude Code