### PR TITLE
chore: inline renovate-supply-chain preset as workaround

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "github>jubilee-works/timetree-github-actions:renovate-supply-chain"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "extractVersion": "^(?<version>v?\\d+(\\.\\d+)*)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$"
+    },
+    {
+      "matchDepTypes": ["action"],
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## 内容

`renovate.json` の `extends` で参照していたprivate repo上のpresetをRenovateが解決できなかったため、preset内容をそのままインライン化した。

- `extends`: 組み込みpreset `helpers:pinGitHubActionDigests` を直接指定
- `minimumReleaseAge`: `7 days` を追加
- `packageRules`: action versionコメントの記録ルール、pinDigest時のcooldown解除ルールを追加

## Test plan

- [x] `jq . renovate.json` でJSON構文が正しいことを確認
- [x] `deno fmt --check renovate.json` でフォーマットが正しいことを確認
- [ ] マージ後、Renovateが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)